### PR TITLE
change docker image name in github workflows

### DIFF
--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -100,8 +100,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-            ${{ secrets.DOCKER_USERNAME }}/docker-condalock-jupyterlab:latest
-            ${{ secrets.DOCKER_USERNAME }}/docker-condalock-jupyterlab:${{ github.sha }}
-            ${{ secrets.DOCKER_USERNAME }}/docker-condalock-jupyterlab:${{ github.ref_name }}
-          cache-from: type=registry,ref=${{ secrets.DOCKER_USERNAME }}/docker-condalock-jupyterlab:buildcache
-          cache-to: type=registry,ref=${{ secrets.DOCKER_USERNAME }}/docker-condalock-jupyterlab:buildcache,mode=max
+            ${{ secrets.DOCKER_USERNAME }}/wine-quality-predictor:latest
+            ${{ secrets.DOCKER_USERNAME }}/wine-quality-predictor:${{ github.sha }}
+            ${{ secrets.DOCKER_USERNAME }}/wine-quality-predictor:${{ github.ref_name }}
+          cache-from: type=registry,ref=${{ secrets.DOCKER_USERNAME }}/wine-quality-predictor:buildcache
+          cache-to: type=registry,ref=${{ secrets.DOCKER_USERNAME }}/wine-quality-predictor:buildcache,mode=max


### PR DESCRIPTION
I changed the docker image name fromdocker-condalock-jupyterlab to  wine-quality-predictor to align with our project name.